### PR TITLE
Start animating from a very small scale.

### DIFF
--- a/assets/css/1-tools/animations.scss
+++ b/assets/css/1-tools/animations.scss
@@ -6,7 +6,7 @@
 
 
 @include keyframes(bounceOut) { 
-  0% { @include transform(matrix3d(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)); }
+  0% { @include transform(matrix3d(0.01, 0, 0, 0, 0, 0.01, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)); }
   2.222222% { @include transform(matrix3d(0.22857, 0.05116, 0, 0, 0.0338, 0.22857, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)); }
   4.444444% { @include transform(matrix3d(0.45383, 0.15188, 0, 0, 0.09925, 0.45383, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)); }
   6.666667% { @include transform(matrix3d(0.65416, 0.23546, 0, 0, 0.1534, 0.65416, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)); }

--- a/assets/css/3-sections/_work.sass
+++ b/assets/css/3-sections/_work.sass
@@ -42,9 +42,8 @@
       +display(flex)
       +align-items(center)
       +justify-content(space-around)
-      +transform(matrix3d(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
       opacity: 0
-      +transition(opacity, 300ms, ease-in, 500ms)
+      +transition(opacity, 300ms, ease-in)
       
       
       strong


### PR DESCRIPTION
This should actually fix the "flickering".

Decided to leave `opacity` transition, because it's softens the disappearance of `.thumb-overlay` (we can't animate `:hover` class when it's not there, i.e. it just ends abruptly when cursor leaves the `.thumb` tile), although it seems to only work this way with Firefox.

Props to @ZDesign, his pull request #23 prompted me to find another way to solve this.

At the end of the day I'm not really sure what causes it to essentially drop `transform` rules (or make them normal, i.e. scale element to 100% instead of 0%) and [the spec is still pretty much unreadable](http://dev.w3.org/csswg/css-transforms/), so I just tried to get away from extreme values.
