### PR TITLE
Make inline SVG fill parent element by default.

### DIFF
--- a/assets/css/2-base/_base.sass
+++ b/assets/css/2-base/_base.sass
@@ -95,6 +95,8 @@ body
   -webkit-font-smoothing: antialiased
   -webkit-text-size-adjust: 100%
 
+svg
+  +size(100%)
 
 h3
   @extend %small-bold


### PR DESCRIPTION
Fixes a small hover area bug for **Return** button:

![hover-area-bug](https://cloud.githubusercontent.com/assets/389387/3647315/fc3ba0f2-10fc-11e4-91f8-e175be0a1149.gif)

Just [a quirk in specification](http://www.w3.org/TR/CSS2/visudet.html#inline-replaced-height) and [browser vendors are OK with it](https://bugzilla.mozilla.org/show_bug.cgi?id=736431).
