### PR TITLE
Adjusted settings blurb to use markdown and make settings.yml easier to read

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -23,7 +23,11 @@ menu:
 # NOTE: The avatar is defined in the all.sass document.
 
 
-blurb: <p><strong>Travis specializes in making things</strong> for human people. Most of the things he makes are <a href="http://travisneilson.com">digital interfaces</a>, but he also puts effort into crafting <a href="http://soundcloud.com/travis-neilson">next-level beats</a> and <a href="http://youtube.com/user/devtipsfordesigners">YouTube videos</a> about making codes happen.</p>
+blurb: >
+  **Travis specializes in making things** for human people.
+  Most of the things he makes are [digital interfaces](http://travisneilson.com), 
+  but he also puts effort into crafting [next-level beats](http://soundcloud.com/travis-neilson) 
+  and [YouTube videos](http://youtube.com/user/devtipsfordesigners) about making codes happen.
 
 
 skills:

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -15,7 +15,7 @@
   
   
   <div class="blurb">
-    {{ site.data.settings.blurb }}
+    {{ site.data.settings.blurb | markdownify }}
   </div>
   
   {% if site.data.settings.skills %}


### PR DESCRIPTION
Travis, 

Your DevTips series on YouTube is absolute Gold. Well done. I don't know if this will help or not, but I tried to make the blurb yaml entry on the settings.yml a little more legible. 

I accomplished that by adjusting the settings.yml blurb to use markdown and make settings page easier to read. Also, added the markdownify filter to properly render markdown on the about section include.

I hope this helps!

Sincerely, 
Brian Z.
