### PR TITLE
Automatic copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
         {% endfor %}
       </nav>
       
-      <p class="copyright">All content copyright 2014</p>
+      <p class="copyright">All content copyright {{ site.time | date: '%Y' }}</p>
     </div>
     
   </div>


### PR DESCRIPTION
The title says it all :wink:... The 'All content copyright (YEAR)' is now always the current year using: `{{ site.time | date: '%Y' }}`