### PR TITLE
Added Testing Settings

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -103,5 +103,7 @@ social:
   
   
   
-  
+ #-------------------------------
+#Testing Settings
+local: true
   

--- a/index.html
+++ b/index.html
@@ -31,11 +31,14 @@
 
 {% include form.html %}
 
-
 {% include footer.html %}
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="assets/js/functions.js"></script>
 <!-- REMEMBER TO ADD ANALYTICS! -->
+{% if site.data.settings.local %}
+//Scripts for live reloading or testing
+<script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
+{% endif %}
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
 <!-- REMEMBER TO ADD ANALYTICS! -->
 {% if site.data.settings.local %}
 //Scripts for live reloading or testing
+//LiveReload (http://livereload.com/) LiveReload Browser Extensions (hhttp://go.livereload.com/extensions)
 <script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
 {% endif %}
 </body>


### PR DESCRIPTION
Now there is a condition in the index.html to have live reloading when on local machine and when you want to deploy simple set local to false.

A developer simply needs to have LiveReload installed on their computer (Windows or Mac) and select the _site folder in LiveReload site folders options. This will reload the page when jekyll regenerates after files have been changes so that you don't have to worry about going to reload the page after each change. This will reduce the time taken between iterations.