### PR TITLE
use liquid to set active-client markup; can't click .client-controls @ 768px

### DIFF
--- a/_includes/clients.html
+++ b/_includes/clients.html
@@ -2,8 +2,12 @@
 
   <h3 id="clients">Clients</h3>
 
+  {% if forloop.first %}
+  	<div class="clients-mobile-nav active-client">
+  {% else %}
+  	<div class="clients-mobile-nav">
+  {% endif %}
   
-  <div class="clients-mobile-nav">
     {% for client in site.data.settings.clients %}
     <span></span>
     {% endfor %}
@@ -15,7 +19,11 @@
     
     
     {% for client in site.data.settings.clients %}
-    <div class="client-unit">
+    {% if forloop.first %}
+    	<div class="client-unit active-client">
+	{% else %}
+		<div class="client-unit">
+	{% endif %}
       
       <figure class="client-face">
         <img src="assets/img/clients/{{ client.avatar }}" alt="client-face">
@@ -41,10 +49,13 @@
   </div>
   
   
-  
   <div class="clients-logos">
     {% for client in site.data.settings.clients %}
-    <img class="client-logo" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
+	    {% if forloop.first %} 
+	    	<img class="client-logo active-client" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
+	    {% else %}
+			<img class="client-logo" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
+		{% endif %}
     {% endfor %}
   </div>
   

--- a/_includes/clients.html
+++ b/_includes/clients.html
@@ -2,14 +2,14 @@
 
   <h3 id="clients">Clients</h3>
 
-  {% if forloop.first %}
-  	<div class="clients-mobile-nav active-client">
-  {% else %}
-  	<div class="clients-mobile-nav">
-  {% endif %}
   
+  <div class="clients-mobile-nav">
     {% for client in site.data.settings.clients %}
-    <span></span>
+    	{% if forloop.first %}
+    		<span class="active-client"></span>
+    	{% else %}
+    		<span></span>
+    	{% endif %}
     {% endfor %}
   </div>
   

--- a/assets/css/3-sections/_clients.sass
+++ b/assets/css/3-sections/_clients.sass
@@ -82,6 +82,7 @@
 // Controls
 .client-controls
   +position(absolute, 0px 0px 0px 0px) 
+  z-index: 2
   
   > div
     +size(40px)

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -65,11 +65,6 @@ function  workLoad() {
 
 function clientStuff() {
   
-  $('.client-unit').first().addClass('active-client');
-  $('.client-logo').first().addClass('active-client');
-  $('.clients-mobile-nav span').first().addClass('active-client');
-  
-  
   $('.client-logo, .clients-mobile-nav span').click(function() {
     var $this = $(this),
         $siblings = $this.parent().children(),

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -65,6 +65,11 @@ function  workLoad() {
 
 function clientStuff() {
   
+  // $('.client-unit').first().addClass('active-client');
+  // $('.client-logo').first().addClass('active-client');
+  // $('.clients-mobile-nav span').first().addClass('active-client');
+  
+  
   $('.client-logo, .clients-mobile-nav span').click(function() {
     var $this = $(this),
         $siblings = $this.parent().children(),

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -65,11 +65,6 @@ function  workLoad() {
 
 function clientStuff() {
   
-  // $('.client-unit').first().addClass('active-client');
-  // $('.client-logo').first().addClass('active-client');
-  // $('.clients-mobile-nav span').first().addClass('active-client');
-  
-  
   $('.client-logo, .clients-mobile-nav span').click(function() {
     var $this = $(this),
         $siblings = $this.parent().children(),


### PR DESCRIPTION
1 Liquid's `forloop` object has a [first property](http://docs.shopify.com/themes/liquid-documentation/objects/for-loops#first). Although it takes more markup to use it, I figured we could rely on liquid vs DOM manipulation where possible.  