### PR TITLE
Margin for mobile and border shrinking

### DIFF
--- a/assets/css/3-sections/_header.sass
+++ b/assets/css/3-sections/_header.sass
@@ -36,7 +36,7 @@ header
     color: white
     text-transform: uppercase
     letter-spacing: 0.05em
-    margin-bottom: 20px
+    margin-bottom: 20px !important
     clear: both
     padding-top: 100px
     
@@ -65,4 +65,8 @@ header
     
     h1
       padding-top: 0px
+      margin: 0 10px
+      
+      span
+        border-width: 7px
     


### PR DESCRIPTION
Hey Travis!
One of the things that I really don't like, and on mobile - I would say, hate - is that there's no margin on the sides of the screen. The white border sticks to the side of the phone's screen and that's (to me) really annoying. I would do a margin: 0 5px or something to the whole white border.

Another thing, is the border itself - I think it should match the weight of the text. Meaning, when the text gets smaller, the border should be thiner. 

Hope my solution is good enough - I didn't have time ti make something that looks better- but notice that the border becomes 7px on mobile and it stays that way, instead of being the same width as the title's font. Maybe if I could get the size of the title from the FitText plugin I could use it to change (with jQuery) the width of the border dynamically with the text...

Also note that I used !important to override the margin: 0 on mobile, instead of doing
margin-right: 10px
margin-left: 10px

I think this is good enough but I'm sure you can find a better solution... :smiley: 

Can't wait to see the next video!

-Reuven
