### PR TITLE
update form css - full width input and button for small screen size

### DIFF
--- a/assets/css/3-sections/_form.sass
+++ b/assets/css/3-sections/_form.sass
@@ -56,3 +56,20 @@ form
     
     span
       display: block
+
+@media (max-width: 420px)
+  form
+
+    .contact-info-group
+    
+      label
+        width: 100%
+      
+        &:nth-child(1)
+          padding: 0
+      
+        &:nth-child(2)
+          padding: 0
+        
+    [type="submit"]
+      width: 100%


### PR DESCRIPTION
at screen width 420px and smaller will have the name and email input will go to 100% width and the send button will also become full width.

This helps usability on smaller screens. Full width inputs allows for more content to be shown within the input on smaller screens.