### PR TITLE
Change form action url

### DIFF
--- a/_includes/form.html
+++ b/_includes/form.html
@@ -2,7 +2,7 @@
 
   <h3>Let's work together</h3>
   
-<form method="POST" action="//forms.brace.io/{{ site.data.settings.email }}">
+<form method="POST" action="//formspree.io/{{ site.data.settings.email }}">
   
   <div class="contact-info-group">
 


### PR DESCRIPTION
brace.io is gone
http://blog.brace.io/2015/01/26/goodbye/

Changed url to formspree.io