### PR TITLE
Client section enhancements

### DIFF
--- a/_includes/clients.html
+++ b/_includes/clients.html
@@ -4,11 +4,7 @@
 
   <div class="clients-mobile-nav">
     {% for client in site.data.settings.clients %}
-      {% if forloop.first %}
-        <span class="active-client"></span>
-      {% else %}
-        <span></span>
-      {% endif %}
+        <span class="client-button {% if forloop.first %}active-client{% endif %}"></span>
     {% endfor %}
   </div>
 
@@ -40,11 +36,7 @@
 
   <div class="clients-logos">
     {% for client in site.data.settings.clients %}
-      {% if forloop.first %}
-        <img class="client-logo active-client" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
-      {% else %}
-        <img class="client-logo" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
-      {% endif %}
+        <img class="client-logo {% if forloop.first %}active-client{% endif %}" src="assets/img/clients/{{ client.logo }}" align="{{ client.logo }}">
     {% endfor %}
   </div>
 

--- a/assets/css/3-sections/_clients.sass
+++ b/assets/css/3-sections/_clients.sass
@@ -49,6 +49,7 @@
 // Logos
 .clients-logos
   position: relative
+  z-index: 3
   max-width: 750px
   margin: 0px auto 100px
   +display(flex)

--- a/assets/css/3-sections/_clients.sass
+++ b/assets/css/3-sections/_clients.sass
@@ -17,7 +17,7 @@
       @extend %#{$animation}
     
     .client-face
-      min-width: 300px
+      min-width: 180px
       text-align: center
       
       img
@@ -103,7 +103,7 @@
 .clients-mobile-nav
   text-align: center
   position: relative
-  z-index: 2
+  z-index: 3
   display: none
   
   span
@@ -120,7 +120,7 @@
     
     
 
-@media (max-width: 750px)
+@media (max-width: 850px)
   .clients-logos
     +flex-wrap(wrap)
   
@@ -130,7 +130,7 @@
     .client-unit.active-client
       display: block
       position: relative
-      margin-left: 0px
+      margin-left: auto
       left: auto
     
       .client-face
@@ -143,9 +143,6 @@
       
       .client-quote-mark
         left: 6px
-
-  .client-controls
-    display: none
   
   .clients-logos
     display: none
@@ -154,9 +151,7 @@
     display: block
     
     
-    
-    
-    
-    
-    
+@media (max-width: 600px)
+  .client-controls
+    display: none
     

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -66,14 +66,13 @@ function  workLoad() {
 
 function clientStuff() {
   
-  $('.client-logo, .clients-mobile-nav span').click(function() {
+  $('.client-logo, .client-button').click(function() {
     var $this = $(this),
-        $siblings = $this.parent().children(),
-        position = $siblings.index($this);
+        position = $this.parent().children().index($this);
         
     $('.client-unit').removeClass('active-client').eq(position).addClass('active-client');
-    $siblings.removeClass('active-client');
-    $this.addClass('active-client');
+    $('.client-logo').removeClass('active-client').eq(position).addClass('active-client');
+    $('.client-button').removeClass('active-client').eq(position).addClass('active-client');
   });
   
   
@@ -91,6 +90,7 @@ function clientStuff() {
         } else {
           $('.client-unit').removeClass('active-client').first().addClass('active-client');
           $('.client-logo').removeClass('active-client').first().addClass('active-client');
+          $('.client-button').removeClass('active-client').first().addClass('active-client');
         }
         
       } else {
@@ -98,6 +98,7 @@ function clientStuff() {
         if (position === 0) {
           $('.client-unit').removeClass('active-client').last().addClass('active-client');
           $('.client-logo').removeClass('active-client').last().addClass('active-client');
+          $('.client-button').removeClass('active-client').last().addClass('active-client');
         } else {
           $('.active-client').removeClass('active-client').prev().addClass('active-client');  
         }


### PR DESCRIPTION
There were a few issues with the client section that this pull request fixes:
1. The client logos were not clickable because their z index was below the next/prev control's z index, so I fixed it by raising the client logos and mobile nav z index
2. It was possible for the active client-mobile-nav button and the active client-logo button to be different from one another: if you zoomed in and clicked a mobile nav button and then zoomed out, the logo would be set to whatever the previous active one was (it wouldn't get updated).  Also if you zoomed out and clicked the next arrow a bunch of times and then zoomed in, none of the mobile-nav-section buttons would be selected because the clause in the javascript about how to move past the last or first client did not alter the mobile nav buttons.
3. The next / previous arrows collide with the client content right around the transition between desktop and mobile view, so I adjusted the media query to transition sooner and prevent the collision.  I also added a new query at max-width 600px so that the arrows stay on screen for longer before disappearing. (Here's my math: the arrows are 40 + 10 px each, the content is 750 px, so the transition should occur at 850px. The mobile view quote is 400 px, so transitioning at 600 px allows space for the arrows plus 50 px margin on each side.) 
4. The min-width for the client's face was set to 300px -- if zoomed in more than that, it goes off-center, so I lowered the min-width to 180px so that it stays centered for longer.
