### PR TITLE
Adding webrick dependency and fixed syntax error in assets/css/all.sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Subscribe to [the channel](https://www.youtube.com/user/DevTipsForDesigners) to 
 In order to get this super fantastic [Jekyll](http://jekyllrb.com) powered template for Artists follow this simple step:
 
 * If you haven't got ruby installed on your computer, install it.
-* Then run in your terminal `$ gem install jekyll`
+* Then run in your terminal `$ gem install jekyll webrick`
 * Move/`cd` to a folder, always in your terminal, in which you want to insert the *Artists-Theme*
 * Run `git clone https://github.com/DevTips/Artists-Theme.git`
 * Then `cd Artists-Theme`

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -10,7 +10,7 @@ $logo-path: '{{ site.data.layout.logo }}'
 $hero-path: '{{ site.data.layout.hero }}'
 $avatar-path: '{{ site.data.layout.avatar }}'
 
-$projects: {% for project in site.data.settings.projects %} "{{ project.folder }}", {% endfor %}
+$projects: [ {% for project in site.data.settings.projects %} "{{ project.folder }}", {% endfor %} ]
 
 //------------------------------------------------
 // Set some colors as sass variables


### PR DESCRIPTION
This fixes the bugs reported by:
* https://github.com/DevTips/Artists-Theme/issues/105
* https://github.com/DevTips/Artists-Theme/issues/106

I'm using jekyll-4.2.0 and webrick-1.7.0 on ruby 3.0.0p0 (2020-12-25 revision 95aff21468).
